### PR TITLE
Fix bundler install step in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,6 +12,6 @@ WORKDIR /workspace
 COPY Gemfile Gemfile.lock ./
 
 RUN gem install bundler && \
-    bundle install || true
+    bundle install
 
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- remove `|| true` from `bundle install` command so bundler failures stop the build

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68405bb07a44832e815794680d0f74da